### PR TITLE
make banner optional

### DIFF
--- a/templates/partials/banner.html
+++ b/templates/partials/banner.html
@@ -1,3 +1,4 @@
+{% if config.extra.quote or config.extra.site_description %}
 <div class="bg-blue-500 text-white shadow-md">
   <div class="max-w-7xl mx-auto py-8 px-4 sm:px-6 lg:px-8">
     <div>
@@ -14,3 +15,4 @@
     </div>
   </div>
 </div>
+{% endif %}


### PR DESCRIPTION
Very minor change:

If no `config.extra.quote` or `config.extra.site_description` is provided, don't add the banner template to a page.

I believe that would be a "sane default" for making those two parameters optional.